### PR TITLE
Destroyed sound fixed

### DIFF
--- a/.idea/.idea.Arrow-VR-master/.idea/workspace.xml
+++ b/.idea/.idea.Arrow-VR-master/.idea/workspace.xml
@@ -2,11 +2,10 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="e9087dad-26c5-4ca3-ae59-3a4c7dcb93b5" name="Default Changelist" comment="">
-      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/.idea.Arrow-VR-master/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Arrow-VR-master/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/BowArrow/Arrow.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/BowArrow/Arrow.cs" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Assets/Scripts/Crate/Crate.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Crate/Crate.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/fmod_editor.log" beforeDir="false" afterPath="$PROJECT_DIR$/fmod_editor.log" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/LevelManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/LevelManager.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/DestroyingEnemies.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/DestroyingEnemies.cs" afterDir="false" />
     </list>
     <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
     <option name="SHOW_DIALOG" value="false" />
@@ -87,7 +86,6 @@
         <option value="$PROJECT_DIR$/Assets/Scripts/ArrowTipColorChecker.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/MainMenu/StartWaveMiniGame.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/MainMenu/ReturnToMainMenu.cs" />
-        <option value="$PROJECT_DIR$/Assets/Scripts/LevelManager.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/AllLevels/CleanSceneBrokenModels.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/AllLevels/LevelManager.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/Arrow.cs" />
@@ -112,7 +110,6 @@
         <option value="$PROJECT_DIR$/Assets/Scripts/MainMenu/RespawnTargets.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/WaveBasedLevel/ArrowTipColorChecker.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/WaveBasedLevel/TimeController.cs" />
-        <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/DestroyingEnemies.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/SpecialAbilitiesBar.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/Enemy/EnemyBehaviour.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/StartGame.cs" />
@@ -131,6 +128,8 @@
         <option value="$PROJECT_DIR$/Assets/Scripts/Audio/FmodBackgroundMusicManager.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/BowArrow/Arrow.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/Crate/Crate.cs" />
+        <option value="$PROJECT_DIR$/Assets/Scripts/LevelManager.cs" />
+        <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/DestroyingEnemies.cs" />
       </list>
     </option>
   </component>
@@ -231,7 +230,7 @@
       <workItem from="1599666320731" duration="597000" />
       <workItem from="1599830200901" duration="1660000" />
       <workItem from="1600077089815" duration="7927000" />
-      <workItem from="1600163827216" duration="1099000" />
+      <workItem from="1600163827216" duration="2294000" />
     </task>
     <servers />
   </component>

--- a/Assets/Scripts/Crate/Crate.cs
+++ b/Assets/Scripts/Crate/Crate.cs
@@ -9,7 +9,7 @@ namespace Crate
         public LevelManager levelManager;
         public string levelChosen;
         public string soundPath;
-
+        
         public void Damage(int amount)
         {
             DestroyCrate();
@@ -26,7 +26,7 @@ namespace Crate
                 levelManager.StartSelectedGameMode(levelChosen);
                 FMODUnity.RuntimeManager.PlayOneShot(soundPath, transform.position);
                 Instantiate(destroyedCrate, transform.position, transform.rotation);
-                Destroy(gameObject);   
+                Destroy(gameObject);
             }
         }
     }

--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -7,11 +6,16 @@ public class LevelManager : MonoBehaviour
 {
     public Animator fadeToNextLevelAnimator;
     private static readonly int FadeToBlack = Animator.StringToHash("FadeToBlack");
+    
+    // Prevent instantiation on destroyed enemies 1
+    private bool _sceneChanging;
 
     public void StartSelectedGameMode(string levelName)
     {
-        print("******************************** SCENE CHNAGE ********************************");
         if(fadeToNextLevelAnimator) fadeToNextLevelAnimator.SetBool(FadeToBlack, true);
+        
+        // Prevent instantiation on destroyed enemies 2
+        _sceneChanging = true;
         StartCoroutine(LoadNextLevel(levelName));
     }
 
@@ -19,5 +23,11 @@ public class LevelManager : MonoBehaviour
     {
         yield return new WaitForSeconds(2f);
         SceneManager.LoadSceneAsync(levelName);
+    }
+    
+    // Prevent instantiation on destroyed enemies 3
+    public bool IsSceneChanging()
+    {
+        return _sceneChanging;
     }
 }

--- a/Assets/Scripts/PillarOfLight/DestroyingEnemies.cs
+++ b/Assets/Scripts/PillarOfLight/DestroyingEnemies.cs
@@ -7,12 +7,16 @@ namespace PillarOfLight
     public class DestroyingEnemies : MonoBehaviour
     {
         public GameObject explosionParticles;
+
         private WaveScore _waveScoreBoard;
         private SpecialAbilitiesBar _specialAbilitiesBar;
         private bool _scoreBoardExists = false;
-
+        private LevelManager _levelManager;
+        
         private void Awake()
         {
+            _levelManager = GameObject.Find("LevelManager").GetComponent<LevelManager>();
+            
             if (GameObject.FindGameObjectWithTag("WaveScoreBoard") != null)
             {
                 _waveScoreBoard = GameObject.FindGameObjectWithTag("WaveScoreBoard").GetComponent<WaveScore>();
@@ -23,6 +27,8 @@ namespace PillarOfLight
 
         private void OnDestroy()
         {
+            if (_levelManager.IsSceneChanging()) return;
+            
             Instantiate(explosionParticles, transform.position + Vector3.up, transform.rotation);
             
             if (_scoreBoardExists)


### PR DESCRIPTION
- Levelmanager sets a boolean when changing level (maybe better as enum
in future?!?)

- Destroying script reads this to check if the scene is changing and if
so won’t play sound or particle effect.