### PR TITLE
round counter for spawn enemy & fix off screen indicator error

### DIFF
--- a/.idea/.idea.Arrow-VR-master/.idea/workspace.xml
+++ b/.idea/.idea.Arrow-VR-master/.idea/workspace.xml
@@ -3,10 +3,9 @@
   <component name="ChangeListManager">
     <list default="true" id="e9087dad-26c5-4ca3-ae59-3a4c7dcb93b5" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/.idea.Arrow-VR-master/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Arrow-VR-master/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scenes/WaveBasedAltLayout.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/WaveBasedAltLayout.unity" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/AllLevels/PlayerPrefChecker.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/AllLevels/PlayerPrefChecker.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/ArrowTipColorChecker.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/ArrowTipColorChecker.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/RespawnGlueBomb.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/RespawnGlueBomb.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Enemy/EnemyBehaviour.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Enemy/EnemyBehaviour.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Enemy/WaveSpawner.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Enemy/WaveSpawner.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/DestroyingEnemies.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/DestroyingEnemies.cs" afterDir="false" />
     </list>
     <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
     <option name="SHOW_DIALOG" value="false" />
@@ -121,7 +120,6 @@
         <option value="$PROJECT_DIR$/Assets/Scripts/AllLevels/CameraFacingBillboard.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/WaveScore.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/PaintBomb.cs" />
-        <option value="$PROJECT_DIR$/Assets/Scripts/Enemy/EnemyBehaviour.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/PowerUpManager.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/RespawnGlueBombs.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/GlueBomb.cs" />
@@ -140,8 +138,6 @@
         <option value="$PROJECT_DIR$/Assets/Scripts/BowArrow/Bow.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/ObtainPowerUp.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/OculusInput.cs" />
-        <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/SpawnRandomPowerUp.cs" />
-        <option value="$PROJECT_DIR$/Assets/Scripts/Enemy/WaveSpawner.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/TargetShooterMiniGame/TargetColour.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/TargetShooterMiniGame/ArrowColourCheckerTargetMiniGame.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/TargetShooterMiniGame/TargetDestructionTimer.cs" />
@@ -152,10 +148,13 @@
         <option value="$PROJECT_DIR$/Assets/Scripts/TargetShooterMiniGame/CountDownTimerGameOver.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/TargetShooterMiniGame/TargetHealth.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/PillarHealth.cs" />
-        <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/DestroyingEnemies.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/ArrowTipColorChecker.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/AllLevels/PlayerPrefChecker.cs" />
         <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/RespawnGlueBomb.cs" />
+        <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/SpawnRandomPowerUp.cs" />
+        <option value="$PROJECT_DIR$/Assets/Scripts/Enemy/WaveSpawner.cs" />
+        <option value="$PROJECT_DIR$/Assets/Scripts/PillarOfLight/DestroyingEnemies.cs" />
+        <option value="$PROJECT_DIR$/Assets/Scripts/Enemy/EnemyBehaviour.cs" />
       </list>
     </option>
   </component>
@@ -269,7 +268,7 @@
       <workItem from="1602154781228" duration="3860000" />
       <workItem from="1602500482587" duration="3148000" />
       <workItem from="1602589673283" duration="13539000" />
-      <workItem from="1602754395920" duration="1282000" />
+      <workItem from="1602754395920" duration="4578000" />
     </task>
     <servers />
   </component>
@@ -301,19 +300,6 @@
           <properties exception="System.Threading.ThreadAbortException" displayValue="System.Threading.ThreadAbortException" />
           <option name="timeStamp" value="1" />
         </breakpoint>
-        <line-breakpoint enabled="true" type="DotNet Breakpoints">
-          <url>file://$PROJECT_DIR$/Assets/Scripts/Enemy/EnemyBehaviour.cs</url>
-          <line>66</line>
-          <properties documentPath="$PROJECT_DIR$/Assets/Scripts/Enemy/EnemyBehaviour.cs" initialLine="65">
-            <startOffsets>
-              <option value="2625" />
-            </startOffsets>
-            <endOffsets>
-              <option value="2649" />
-            </endOffsets>
-          </properties>
-          <option name="timeStamp" value="2" />
-        </line-breakpoint>
       </breakpoints>
     </breakpoint-manager>
   </component>

--- a/Assets/Scripts/Enemy/EnemyBehaviour.cs
+++ b/Assets/Scripts/Enemy/EnemyBehaviour.cs
@@ -24,6 +24,8 @@ namespace Enemy
         private NavMeshAgent _agent;
         private Animator _attackAnimation;
         private WaveSpawner _waveSpawnedInformation;
+        private DestroyingEnemies _destroyingEnemies;
+        private DestroyLargeEnemy _destroyLargeEnemy;
 
         private PillarHealth _pillarHealth;
         private bool _readyToAttack;
@@ -42,11 +44,13 @@ namespace Enemy
             {
                 _attackPositions = new Transform[] {GameObject.Find("RedAttackPos").transform, GameObject.Find("GreenAttackPos").transform, GameObject.Find("BlueAttackPos").transform};
                 _target = GetClosestAttackPosition(_attackPositions);
+                _destroyingEnemies = GetComponent<DestroyingEnemies>();
             }
             else
             {
                 _attackPositions = new Transform[] {GameObject.Find("LargeRedAttackPos").transform, GameObject.Find("LargeGreenAttackPos").transform, GameObject.Find("LargeBlueAttackPos").transform};
-                _target = GetClosestAttackPosition(_attackPositions);   
+                _target = GetClosestAttackPosition(_attackPositions);
+                _destroyLargeEnemy = GetComponent<DestroyLargeEnemy>();
             }
         }
 
@@ -125,8 +129,10 @@ namespace Enemy
         private IEnumerator SelfDestroy()
         {
             yield return  new WaitForSeconds(1.5f);
-            Instantiate(fracturedSelf, transform.position, transform.rotation);
-            Destroy(gameObject);
+            // Add Damage code
+            if (isLargeEnemy) _destroyLargeEnemy.Damage(100);
+            if (!isLargeEnemy) _destroyingEnemies.Damage(10);
+
         } 
     
         // Called as an animation event on swinging animation

--- a/Assets/Scripts/Enemy/WaveSpawner.cs
+++ b/Assets/Scripts/Enemy/WaveSpawner.cs
@@ -25,6 +25,7 @@ namespace Enemy
         private SpawnState _state = SpawnState.Counting;
         private GameObject _pillarOfLight;
         private SpawnRandomPowerUp _spawnRandomPowerUp;
+        private float _spawnability;
 
         private void Start()
         {
@@ -126,12 +127,27 @@ namespace Enemy
                 yield return new WaitForSeconds(1f/(wave.spawnRate + currentRoundNumber));
             }
             
-            if(Random.value > 0.8) SpawnEnemy(largeEnemy.transform);
+            SpawnLargeEnemy();
 
             // After all enemies spawned set spawn system state to waiting
             _state = SpawnState.Waiting;
             
             yield break;
+        }
+
+        private void SpawnLargeEnemy()
+        {
+            if(RoundCount >= 0 && RoundCount <= 2) _spawnability = 0.8f;
+            if(RoundCount >= 3 && RoundCount <= 5) _spawnability = 0.5f;
+            if(RoundCount >= 6) _spawnability = 0.3f;
+
+            if (Random.value > _spawnability)
+            {
+                for (float i = 0; i<=RoundCount; i++)
+                {
+                    SpawnEnemy(largeEnemy.transform);
+                }
+            }
         }
 
         private void SpawnEnemy(Transform enemy)

--- a/Assets/Scripts/PillarOfLight/DestroyingEnemies.cs
+++ b/Assets/Scripts/PillarOfLight/DestroyingEnemies.cs
@@ -1,4 +1,5 @@
-﻿using Crate;
+﻿using System;
+using Crate;
 using Greyman;
 using UnityEngine;
 
@@ -35,6 +36,14 @@ namespace PillarOfLight
             {
                 _offScreenIndicator.AddIndicator(gameObject.transform, 2);
             } 
+        }
+
+        private void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.Space))
+            {
+                Damage(10);
+            }
         }
 
         public void Damage(int amount)


### PR DESCRIPTION
- Large enemies now spawn differently on round count.

- Offscreen indicator was not being removed correctly when pillar
destroyed them.
- Now pillar being destroyed will call IDamageable on each enemy within
the level.